### PR TITLE
Deslop V4 changes (drop redundant version tags)

### DIFF
--- a/benchmark/cadence/simulator.py
+++ b/benchmark/cadence/simulator.py
@@ -39,9 +39,9 @@ class Word:
     word: str
     start_ms: int
     end_ms: int
-    # V4 schema extension: per-word ASR confidence (0.0–1.0). Defaults to
-    # 1.0 for legacy word_timings without confidence so downstream
-    # consumers see "fully trusted" rather than "completely untrusted".
+    # Per-word ASR confidence (0.0–1.0). Defaults to 1.0 for legacy
+    # word_timings without confidence so downstream consumers see
+    # "fully trusted" rather than "completely untrusted".
     confidence: float = 1.0
 
 
@@ -112,8 +112,9 @@ def split_into_sessions(words: list[Word], profile: dict) -> list[list[Word]]:
 def render_clean_passthrough(words: list[Word], profile: dict) -> list[dict]:
     """Each word = one final event at its start_ms with text = that word.
 
-    V4 schema: each event carries `confidences: [c]` and `mean_confidence: c`
-    so V4 matcher can read the per-event confidence without re-aggregating.
+    Each event carries `confidences: [c]` and `mean_confidence: c` so
+    confidence-aware matchers can read the per-event value without
+    re-aggregating.
     """
     events = [
         {

--- a/lib/services/script_matcher_v3.dart
+++ b/lib/services/script_matcher_v3.dart
@@ -204,7 +204,6 @@ class ScriptMatcherV3 implements ScriptMatcherBase {
     // the boundary.
   }
 
-  // V4-only hook: V3 ignores per-event confidence (it has no gate).
   @override
   void setNextEventConfidence(double meanConfidence) {}
 

--- a/lib/services/script_matcher_v4.dart
+++ b/lib/services/script_matcher_v4.dart
@@ -71,18 +71,17 @@ class ScriptMatcherV4 implements ScriptMatcherBase {
   static const int _staleThreshold = 4;
   static const int _resyncLookahead = 6;
 
-  // V3-style post-reset partial-recovery budget
+  // Post-reset partial-recovery budget (inherited from V3).
   int _postResetPartialBudget = 0;
   static const int _postResetPartialBudgetSize = 8;
 
-  // V4-only: most-recent mean confidence forwarded by the host before
-  // the next match() call. Defaults to 1.0 so legacy events without
-  // confidence behave identically to V3.
+  // Most-recent mean confidence forwarded by the host before the next
+  // match() call. Defaults to 1.0 so legacy events without confidence
+  // behave identically to V3 (default-trust contract).
   double _nextMeanConfidence = 1.0;
 
-  // V4 confidence threshold: partials with mean confidence below this
-  // value cannot trigger post-reset recovery (we trust them less than
-  // V3's recovery-on-partial path requires). Calibrated against the
+  // Confidence threshold: partials with mean confidence below this
+  // value cannot trigger post-reset recovery. Calibrated against the
   // JFK Vosk events: 0.46 (cafe-noise-snr-10) vs 0.96 (clean) — 0.6
   // sits in the dead zone. See benchmark/reports/v4-vs-v3-report.md
   // for the calibration sweep.
@@ -110,7 +109,7 @@ class ScriptMatcherV4 implements ScriptMatcherBase {
   @override
   int get totalSentences => _script?.sentences.length ?? 0;
 
-  /// V4: host forwards the inbound event's mean confidence here before
+  /// Host forwards the inbound event's mean confidence here before
   /// each match() call. Stored until consumed in the next match().
   @override
   void setNextEventConfidence(double meanConfidence) {


### PR DESCRIPTION
Bounded ai-slop-cleaner pass on the V4 ralph-session changed files. Drops `V4-only:` / `V4 schema:` / `V3-style ...` inline tags that restate context. Load-bearing context (threshold 0.6 calibration, default-trust contract) preserved.

Verified byte-identical to V4 pre-deslop:
- flutter analyze: 0 issues across 7 files
- V4 metrics on cafe-noise-snr-10 / jfk ios / tts_jfk ios / jfk clean-passthrough: MAE / stall / x-rec all unchanged (diff exit 0)

Refs: #7